### PR TITLE
docs: add Fronteir AI hosted deployment option

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,10 @@ This is a TypeScript-based MCP server that provides tools to interact with Confl
 
 ## Features
 
+## Hosted deployment
+
+A hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/ks-gen-ai-confluence-mcp-server).
+
 ## Confluence Tools
 
 ### `execute_cql_search`


### PR DESCRIPTION
Love the project!

Adds a short note in the README that a hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/ks-gen-ai-confluence-mcp-server).